### PR TITLE
Raise an exception in development env if the translation is missing, or interpolation arguments do not match

### DIFF
--- a/spec/support/dummy.rb
+++ b/spec/support/dummy.rb
@@ -7,6 +7,10 @@ class Dummy
     object_with_name.name
   end
 
+  def foo(some_arg, another_arg)
+    [some_arg, another_arg]
+  end
+
   def namespace
     @namespace ||= :dummy
   end


### PR DESCRIPTION
When in production env the exception will be logged in audit.log and silenced