### PR TITLE
Fix missing argument

### DIFF
--- a/app/models/google_integration/api.rb
+++ b/app/models/google_integration/api.rb
@@ -155,11 +155,11 @@ module GoogleIntegration
       end
     end
 
-    def create_user(_params)
-      force_user_authorization { request(params_request_for_creating_user) }
+    def create_user(params)
+      force_user_authorization { request(params_request_for_creating_user(params)) }
     end
 
-    def params_request_for_creating_user
+    def params_request_for_creating_user(params)
       {
         api_method: directory_api.users.insert,
         body_object: {

--- a/spec/models/google_integration/actions/create_accounts_spec.rb
+++ b/spec/models/google_integration/actions/create_accounts_spec.rb
@@ -6,10 +6,29 @@ RSpec.describe GoogleIntegration::Actions::CreateAccounts do
 
   let(:accounts) { ['first.member', 'second.member'] }
   let(:user_repo) { UserRepository.new(data_guru.members) }
+  let(:create_accounts_params) do
+    [
+      {
+        first_name: 'First',
+        last_name: 'Member',
+        email: 'first.member@netguru.pl',
+        password: 'abcdefgh',
+        login: 'first.member',
+      },
+      {
+        first_name: 'Second',
+        last_name: 'Member',
+        email: 'second.member@netguru.pl',
+        password: 'abcdefgh',
+        login: 'second.member',
+      },
+    ]
+  end
   subject { described_class.new(google_api, user_repo).now!(accounts) }
   before do
     allow_any_instance_of(described_class).to receive(:sleep)
     allow(DataGuru::Client).to receive(:new).and_return(data_guru)
+    allow(SecureRandom).to receive(:hex).and_return('abcdefgh')
   end
   it { is_expected.to be_a Hash }
   it { is_expected.to_not be_empty }
@@ -18,4 +37,10 @@ RSpec.describe GoogleIntegration::Actions::CreateAccounts do
   it { expect(subject[accounts.first][:email]).to eq('first.member@netguru.pl') }
   it { expect(subject[accounts.first][:last_name]).to eq('Member') }
   it { expect(subject[accounts.first][:first_name]).to eq('First') }
+
+  it 'calls api with params' do
+    expect(google_api).to receive(:create_user).with(create_accounts_params[0])
+    expect(google_api).to receive(:create_user).with(create_accounts_params[1])
+    subject
+  end
 end


### PR DESCRIPTION
It makes sure that `create_user` gets called with proper params.