### PR TITLE
AI-17 double sync bugfix

### DIFF
--- a/app/models/github_integration/actions/sync.rb
+++ b/app/models/github_integration/actions/sync.rb
@@ -54,7 +54,7 @@ module GithubIntegration
 
       def create_teams(teams_to_create)
         teams_to_create.each do |team, h|
-          @gh_api.create_team(team.name, h[:add_permissions]) do |created_team|
+          @gh_api.create_team(team.name, h[:add_permissions]).tap do |created_team|
             new_team_add_members(h[:add_members], created_team)
             new_team_add_repos(h[:add_repos], created_team)
             new_team_add_permissions(h[:add_permissions], created_team)

--- a/app/models/rollbar_integration/actions/sync.rb
+++ b/app/models/rollbar_integration/actions/sync.rb
@@ -46,7 +46,7 @@ module RollbarIntegration
 
       def create_teams(teams_to_create)
         teams_to_create.each do |team, h|
-          @rollbar_api.create_team(team.name) do |created_team|
+          @rollbar_api.create_team(team.name).tap do |created_team|
             new_team_add_members(h[:add_members], created_team)
             new_team_add_projects(h[:add_projects], created_team)
           end

--- a/app/models/rollbar_integration/api.rb
+++ b/app/models/rollbar_integration/api.rb
@@ -42,7 +42,7 @@ module RollbarIntegration
 
     def create_team(name, access_level = 'standard')
       options = { body: { name: name, access_level: access_level } }
-      team = client.post('/api/1/teams', options)
+      client.post('/api/1/teams', options)
     end
 
     def create_project(name)

--- a/app/models/rollbar_integration/api.rb
+++ b/app/models/rollbar_integration/api.rb
@@ -43,7 +43,6 @@ module RollbarIntegration
     def create_team(name, access_level = 'standard')
       options = { body: { name: name, access_level: access_level } }
       team = client.post('/api/1/teams', options)
-      yield team
     end
 
     def create_project(name)

--- a/spec/models/github_integration/actions/sync_spec.rb
+++ b/spec/models/github_integration/actions/sync_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GithubIntegration::Actions::Sync do
       end
       allow(api).to receive(:create_team) do
         existing_teams.push(new_team)
-      end.and_yield(new_team)
+      end.and_return(new_team)
     end
   end
   let(:team) do

--- a/spec/support/rollbar_api.rb
+++ b/spec/support/rollbar_api.rb
@@ -50,7 +50,7 @@ RSpec.shared_context 'rollbar_api' do
       end
       allow(api).to receive(:create_team) do
         existing_teams.push(new_team)
-      end.and_yield(created_new_team)
+      end.and_return(created_new_team)
       allow(api).to receive(:list_account_projects) { all_projects }
     end
   end


### PR DESCRIPTION
Fix for github and rollbar integration, so they wouldn't require double sync when creating new teams with members and repos or projects. 