### PR TITLE
add status to user when creating from rollbar api

### DIFF
--- a/app/models/rollbar_integration/team.rb
+++ b/app/models/rollbar_integration/team.rb
@@ -67,6 +67,7 @@ module RollbarIntegration
         user = OpenStruct.new(
           username: user_repo.find_by_email(rollbar_user.email).id,
           id: rollbar_user.id,
+          status: rollbar_user.status,
         )
       rescue
         Rollbar.info("There is no user with email: #{rollbar_user.email}")


### PR DESCRIPTION
It fixes a bug, where there is user in log that needs to be removed from a team, but after syncing error appears. Error was caused by `member` not having `status`, resulting in `nil` output that was removing user from team and not cancelling his invitation. 

This fixes it.

https://netguru.atlassian.net/browse/AI-23