### PR TITLE
Feature/improve google directory

### DIFF
--- a/app/controllers/concerns/google_api.rb
+++ b/app/controllers/concerns/google_api.rb
@@ -21,9 +21,9 @@ module GoogleApi
 
     return false if credentials.nil?
     return true if permitted_members.empty?
-    return true if google_api.admin?
+    return true if credentials[:is_admin]
 
-    permitted_members.include? google_api.user_email
+    permitted_members.include? credentials[:email]
   end
 
   def unauthorized_access
@@ -63,7 +63,9 @@ module GoogleApi
 
   def permitted_members
     return [] unless AppConfig.google.managers?
-    prepare_permitted_memerbs.compact.uniq
+    Rails.cache.fetch('permitted_members') do
+      prepare_permitted_memerbs.compact.uniq
+    end
   end
 
   def prepare_permitted_memerbs

--- a/app/models/google_integration/actions/create_accounts.rb
+++ b/app/models/google_integration/actions/create_accounts.rb
@@ -35,7 +35,7 @@ module GoogleIntegration
           first_name: user.name.split(' ').first,
           last_name: user.name.split(' ').last,
           email: "#{login}@#{AppConfig.google.main_domain}",
-          password: SecureRandom.hex(8),
+          password: AppConfig.google.new_user_password,
           login: login,
         }
         @google_api.create_user(params)

--- a/app/models/google_integration/group_policy.rb
+++ b/app/models/google_integration/group_policy.rb
@@ -2,11 +2,11 @@ module GoogleIntegration
   class GroupPolicy
     def self.edit?(group_email, is_admin = false)
       return true if is_admin
-      whitelist.any? { |regexp| regexp.match group_email }
+      !blacklist.include?(group_email.downcase)
     end
 
-    def self.whitelist
-      AppConfig.google.groups_whitelist.map { |group| Regexp.new group }
+    def self.blacklist
+      @_blacklist ||= AppConfig.google.groups_blacklist.map(&:downcase)
     end
   end
 end

--- a/config/config.yml
+++ b/config/config.yml
@@ -18,6 +18,8 @@ google_defaults: &google_defaults
     - 'https://www.googleapis.com/auth/admin.directory.user'
     - 'https://www.googleapis.com/auth/admin.directory.group'
     - 'https://www.googleapis.com/auth/admin.directory.user.security'
+  max_results_size: 500
+  new_user_password: test_password
 
 defaults: &defaults
   cache_data: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -5,7 +5,7 @@ google_defaults: &google_defaults
     group:
       archive: true
       private: false
-  groups_whitelist: [/.*/]
+  groups_blacklist: [blacklisted@test.email]
   main_domain: netguru.pl
   managers:
     groups: [support_group]
@@ -56,7 +56,6 @@ test:
     domain_member_id: dummy
     email:
       account_using_instruction: dummy
-    groups_whitelist: [group1@netguru.pl]
   toggl_token: 'abcdefg'
 
 development:

--- a/config/sec_config.yml.sample
+++ b/config/sec_config.yml.sample
@@ -20,6 +20,7 @@ development:
     scope:
     service_account_email:
     supporter_email:
+    new_user_password:
   permissions_repo:
     url:
     checkout_dir:

--- a/spec/models/google_integration/actions/create_accounts_spec.rb
+++ b/spec/models/google_integration/actions/create_accounts_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe GoogleIntegration::Actions::CreateAccounts do
         first_name: 'First',
         last_name: 'Member',
         email: 'first.member@netguru.pl',
-        password: 'abcdefgh',
+        password: 'test_password',
         login: 'first.member',
       },
       {
         first_name: 'Second',
         last_name: 'Member',
         email: 'second.member@netguru.pl',
-        password: 'abcdefgh',
+        password: 'test_password',
         login: 'second.member',
       },
     ]
@@ -28,7 +28,6 @@ RSpec.describe GoogleIntegration::Actions::CreateAccounts do
   before do
     allow_any_instance_of(described_class).to receive(:sleep)
     allow(DataGuru::Client).to receive(:new).and_return(data_guru)
-    allow(SecureRandom).to receive(:hex).and_return('abcdefgh')
   end
   it { is_expected.to be_a Hash }
   it { is_expected.to_not be_empty }

--- a/spec/models/google_integration/group_policy_spec.rb
+++ b/spec/models/google_integration/group_policy_spec.rb
@@ -9,14 +9,14 @@ module GoogleIntegration
 
       context 'user can edit the group' do
         context 'group is identified by email' do
-          let(:group_identifier) { 'group1@netguru.pl' }
+          let(:group_identifier) { 'not-blacklisted@test.email' }
           it { is_expected.to be_truthy }
         end
       end
 
       context "user can't edit the group" do
         context 'group is identified by email' do
-          let(:group_identifier) { 'new_group@netguru.pl' }
+          let(:group_identifier) { 'blacklisted@test.email' }
           it { is_expected.to be_falsey }
         end
       end


### PR DESCRIPTION
Few changes in google directory management:

1. Call google api only once to fetch user email and `admin` privilege, store in session.
2. Store new user password in config file.
3. Use blacklist instead of whitelist for groups control.
4. Paginage `members.list` call, fixes a maxResults of 200 users bug.
5. Remove some unnecessary authorization calls.

cc @lubieniebieski 